### PR TITLE
ci(release): add codesign for darwin targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,12 @@ jobs:
 
             chmod +x "$outfile" || true
 
+            # bun build --compile leaves an invalid linker signature on macOS.
+            # Re-sign with ad-hoc identity so Gatekeeper won't reject the binary.
+            if [[ "$target" == bun-darwin-* ]]; then
+              codesign -s - --force "$outfile"
+            fi
+
             if [[ "$target" == "$verify_target" ]]; then
               expected="${RELEASE_TAG}+${short_sha}"
               actual="$("$outfile" --version)"


### PR DESCRIPTION
## Summary

- Add codesign step for darwin targets in the release workflow
- Re-sign compiled binaries with ad-hoc identity to fix Gatekeeper issues on macOS

## Changes

### CI/CD

- Added ad-hoc code signing for `bun-darwin-*` targets in `.github/workflows/release.yml:103-107`
- This addresses the issue where `bun build --compile` leaves an invalid linker signature on macOS
- Ensures Gatekeeper won't reject the compiled binaries

## Context

The `bun build --compile` command produces binaries with an invalid linker signature on macOS. This causes Gatekeeper to reject the binaries when users try to run them. By re-signing with the ad-hoc identity (`codesign -s - --force`), we provide a valid signature that allows the binary to run without Gatekeeper blocking it.

## Testing

No code changes to test - this is a CI/CD workflow change.