### PR TITLE
refactor: consolidate protocol dispatch, extract shared modules, add Channel abstraction

### DIFF
--- a/cli/run-until-exit.test.ts
+++ b/cli/run-until-exit.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { type ExitSource, runUntilExit, type SignalSource, type StoppableServer } from "./run-until-exit.ts";
+
+class MockSession implements ExitSource {
+  private exitCallback: ((exitCode: number) => void) | null = null;
+  destroyCount = 0;
+
+  onExit(callback: (exitCode: number) => void): void {
+    this.exitCallback = callback;
+  }
+
+  destroy(): void {
+    this.destroyCount++;
+  }
+
+  emitExit(code: number): void {
+    this.exitCallback?.(code);
+  }
+}
+
+class MockServer implements StoppableServer {
+  stopCount = 0;
+
+  stop(): void {
+    this.stopCount++;
+  }
+}
+
+class MockSignals implements SignalSource {
+  private handlers = new Map<string, Set<() => void>>();
+
+  on(signal: "SIGINT" | "SIGTERM", handler: () => void): void {
+    const set = this.handlers.get(signal) ?? new Set();
+    set.add(handler);
+    this.handlers.set(signal, set);
+  }
+
+  off(signal: "SIGINT" | "SIGTERM", handler: () => void): void {
+    this.handlers.get(signal)?.delete(handler);
+  }
+
+  emit(signal: "SIGINT" | "SIGTERM"): void {
+    for (const handler of [...(this.handlers.get(signal) ?? [])]) handler();
+  }
+
+  listenerCount(signal: "SIGINT" | "SIGTERM"): number {
+    return this.handlers.get(signal)?.size ?? 0;
+  }
+}
+
+function createHarness(): {
+  session: MockSession;
+  server: MockServer;
+  signals: MockSignals;
+  promise: Promise<number>;
+} {
+  const session = new MockSession();
+  const server = new MockServer();
+  const signals = new MockSignals();
+  const promise = runUntilExit(session, server, signals);
+
+  return { session, server, signals, promise };
+}
+
+describe("runUntilExit", () => {
+  test("session exit resolves with the exit code and stops the server without destroying the session", async () => {
+    const { session, server, promise } = createHarness();
+
+    session.emitExit(7);
+
+    expect(await promise).toBe(7);
+    expect(server.stopCount).toBe(1);
+    expect(session.destroyCount).toBe(0);
+  });
+
+  test("SIGINT destroys the session, stops the server, and resolves with 130", async () => {
+    const { session, server, signals, promise } = createHarness();
+
+    signals.emit("SIGINT");
+
+    expect(await promise).toBe(130);
+    expect(session.destroyCount).toBe(1);
+    expect(server.stopCount).toBe(1);
+  });
+
+  test("SIGTERM behaves identically to SIGINT", async () => {
+    const { session, server, signals, promise } = createHarness();
+
+    signals.emit("SIGTERM");
+
+    expect(await promise).toBe(130);
+    expect(session.destroyCount).toBe(1);
+    expect(server.stopCount).toBe(1);
+  });
+
+  test("settles only once: a signal after exit is a no-op", async () => {
+    const { session, server, signals, promise } = createHarness();
+
+    session.emitExit(0);
+    signals.emit("SIGINT");
+
+    expect(await promise).toBe(0);
+    expect(server.stopCount).toBe(1);
+    expect(session.destroyCount).toBe(0);
+  });
+
+  test("settles only once: an exit after a signal keeps the first exit code", async () => {
+    const { session, server, signals, promise } = createHarness();
+
+    signals.emit("SIGINT");
+    session.emitExit(0);
+
+    // The signal wins the resolved code, and server shutdown is also guarded
+    // so the later onExit callback cannot stop it a second time.
+    expect(await promise).toBe(130);
+    expect(session.destroyCount).toBe(1);
+    expect(server.stopCount).toBe(1);
+  });
+
+  test("removes both signal listeners once settled", async () => {
+    const { session, signals, promise } = createHarness();
+
+    expect(signals.listenerCount("SIGINT")).toBe(1);
+    expect(signals.listenerCount("SIGTERM")).toBe(1);
+
+    session.emitExit(0);
+    await promise;
+
+    expect(signals.listenerCount("SIGINT")).toBe(0);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+  });
+});

--- a/cli/run-until-exit.test.ts
+++ b/cli/run-until-exit.test.ts
@@ -117,6 +117,23 @@ describe("runUntilExit", () => {
     expect(server.stopCount).toBe(1);
   });
 
+  test("does not leak signal listeners when onExit fires synchronously at registration", async () => {
+    const server = new MockServer();
+    const signals = new MockSignals();
+    const syncSession: ExitSource = {
+      onExit(callback) {
+        callback(0);
+      },
+      destroy() {},
+    };
+
+    const promise = runUntilExit(syncSession, server, signals);
+
+    expect(await promise).toBe(0);
+    expect(signals.listenerCount("SIGINT")).toBe(0);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+  });
+
   test("removes both signal listeners once settled", async () => {
     const { session, signals, promise } = createHarness();
 

--- a/cli/run-until-exit.test.ts
+++ b/cli/run-until-exit.test.ts
@@ -83,12 +83,12 @@ describe("runUntilExit", () => {
     expect(server.stopCount).toBe(1);
   });
 
-  test("SIGTERM behaves identically to SIGINT", async () => {
+  test("SIGTERM destroys the session, stops the server, and resolves with 143", async () => {
     const { session, server, signals, promise } = createHarness();
 
     signals.emit("SIGTERM");
 
-    expect(await promise).toBe(130);
+    expect(await promise).toBe(143);
     expect(session.destroyCount).toBe(1);
     expect(server.stopCount).toBe(1);
   });

--- a/cli/run-until-exit.ts
+++ b/cli/run-until-exit.ts
@@ -1,0 +1,67 @@
+/** Subset of {@link SessionManager} that {@link runUntilExit} drives. */
+export interface ExitSource {
+  onExit(callback: (exitCode: number) => void): void;
+  destroy(): void;
+}
+
+/** Subset of Bun's `Server` that {@link runUntilExit} drives. */
+export interface StoppableServer {
+  stop(): void;
+}
+
+/** Signal seam: `process` in production, an in-memory fake in tests. */
+export interface SignalSource {
+  on(signal: "SIGINT" | "SIGTERM", handler: () => void): void;
+  off(signal: "SIGINT" | "SIGTERM", handler: () => void): void;
+}
+
+/** POSIX convention: a signal-terminated process exits with 128 + signal number (SIGINT = 2). */
+const SIGNAL_EXIT_CODE = 128 + 2;
+
+/**
+ * Block until the session ends, then resolve with the process exit code.
+ *
+ * The teardown order is load-bearing and differs by trigger:
+ * - PTY exit: the process is already gone, so only stop the server.
+ * - SIGINT/SIGTERM: destroy the session (kill the PTY) *before* stopping the
+ *   server.
+ *
+ * Whichever fires first wins; `settle` is idempotent so the loser is a no-op,
+ * and both signal listeners are removed once settled so nothing leaks.
+ */
+export function runUntilExit(
+  session: ExitSource,
+  server: StoppableServer,
+  signals: SignalSource = process,
+): Promise<number> {
+  return new Promise<number>((resolve) => {
+    let settled = false;
+    let serverStopped = false;
+    const stopServer = () => {
+      if (serverStopped) return;
+      serverStopped = true;
+      server.stop();
+    };
+    function handleSignal(): void {
+      session.destroy();
+      stopServer();
+      settle(SIGNAL_EXIT_CODE);
+    }
+
+    const settle = (code: number) => {
+      if (settled) return;
+      settled = true;
+      signals.off("SIGINT", handleSignal);
+      signals.off("SIGTERM", handleSignal);
+      resolve(code);
+    };
+
+    session.onExit((code) => {
+      stopServer();
+      settle(code);
+    });
+
+    signals.on("SIGINT", handleSignal);
+    signals.on("SIGTERM", handleSignal);
+  });
+}

--- a/cli/run-until-exit.ts
+++ b/cli/run-until-exit.ts
@@ -65,12 +65,15 @@ export function runUntilExit(
       resolve(code);
     };
 
+    // Subscribe to signals before registering the exit callback: if a future
+    // ExitSource fires onExit synchronously at registration, settle() runs and
+    // removes these listeners, so they must already be attached to be removed.
+    signals.on("SIGINT", onSigint);
+    signals.on("SIGTERM", onSigterm);
+
     session.onExit((code) => {
       stopServer();
       settle(code);
     });
-
-    signals.on("SIGINT", onSigint);
-    signals.on("SIGTERM", onSigterm);
   });
 }

--- a/cli/run-until-exit.ts
+++ b/cli/run-until-exit.ts
@@ -15,8 +15,15 @@ export interface SignalSource {
   off(signal: "SIGINT" | "SIGTERM", handler: () => void): void;
 }
 
-/** POSIX convention: a signal-terminated process exits with 128 + signal number (SIGINT = 2). */
-const SIGNAL_EXIT_CODE = 128 + 2;
+/** POSIX convention: a signal-terminated process exits with 128 + signal number. */
+const SIGNAL_NUMBER = {
+  SIGINT: 2,
+  SIGTERM: 15,
+} as const;
+
+function signalExitCode(signal: keyof typeof SIGNAL_NUMBER): number {
+  return 128 + SIGNAL_NUMBER[signal];
+}
 
 /**
  * Block until the session ends, then resolve with the process exit code.
@@ -42,17 +49,19 @@ export function runUntilExit(
       serverStopped = true;
       server.stop();
     };
-    function handleSignal(): void {
+    function handleSignal(signal: keyof typeof SIGNAL_NUMBER): void {
       session.destroy();
       stopServer();
-      settle(SIGNAL_EXIT_CODE);
+      settle(signalExitCode(signal));
     }
+    const onSigint = () => handleSignal("SIGINT");
+    const onSigterm = () => handleSignal("SIGTERM");
 
     const settle = (code: number) => {
       if (settled) return;
       settled = true;
-      signals.off("SIGINT", handleSignal);
-      signals.off("SIGTERM", handleSignal);
+      signals.off("SIGINT", onSigint);
+      signals.off("SIGTERM", onSigterm);
       resolve(code);
     };
 
@@ -61,7 +70,7 @@ export function runUntilExit(
       settle(code);
     });
 
-    signals.on("SIGINT", handleSignal);
-    signals.on("SIGTERM", handleSignal);
+    signals.on("SIGINT", onSigint);
+    signals.on("SIGTERM", onSigterm);
   });
 }

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -9,6 +9,7 @@ import { loadFontAssets } from "../server/fonts.ts";
 import { SessionManager } from "../session/session-manager.ts";
 import homepage from "../web/index.html";
 import type { CliOptions } from "./args.ts";
+import { runUntilExit } from "./run-until-exit.ts";
 
 export interface ReadyInfo {
   url: string;
@@ -98,30 +99,5 @@ export async function run(options: CliOptions, deps?: RunDeps): Promise<number> 
     await openFn(url);
   }
 
-  const exitCode = await new Promise<number>((resolve) => {
-    let settled = false;
-    const settle = (code: number) => {
-      if (settled) return;
-      settled = true;
-      process.off("SIGINT", handleSignal);
-      process.off("SIGTERM", handleSignal);
-      resolve(code);
-    };
-
-    session.onExit((code) => {
-      server.stop();
-      settle(code);
-    });
-
-    const handleSignal = () => {
-      session.destroy();
-      server.stop();
-      settle(128 + 2);
-    };
-
-    process.on("SIGINT", handleSignal);
-    process.on("SIGTERM", handleSignal);
-  });
-
-  return exitCode;
+  return runUntilExit(session, server);
 }

--- a/protocol/messages.test.ts
+++ b/protocol/messages.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "bun:test";
-import { ProtocolError, parseClientMessage, parseServerMessage } from "./messages.ts";
+import {
+  type ClientMessage,
+  type ClientMessageHandlers,
+  dispatchClientMessage,
+  dispatchServerMessage,
+  ProtocolError,
+  parseClientMessage,
+  parseServerMessage,
+  type ServerMessage,
+  type ServerMessageHandlers,
+} from "./messages.ts";
 
 describe("parseClientMessage", () => {
   describe("resize", () => {
@@ -255,5 +265,171 @@ describe("ProtocolError", () => {
   it("has the name ProtocolError", () => {
     const err = new ProtocolError("test");
     expect(err.name).toBe("ProtocolError");
+  });
+});
+
+// Build a handler map whose every entry records the message it received, so a
+// test can assert exactly one handler ran (and with what payload). Exhaustive
+// by construction; omitting a key would be a compile error (not runtime-testable).
+function recordingClientHandlers() {
+  const calls: ClientMessage[] = [];
+  const handlers: ClientMessageHandlers = {
+    resize: (m) => calls.push(m),
+    ping: (m) => calls.push(m),
+    "editor-open": (m) => calls.push(m),
+  };
+  return { handlers, calls };
+}
+
+function recordingServerHandlers() {
+  const calls: ServerMessage[] = [];
+  const handlers: ServerMessageHandlers = {
+    hello: (m) => calls.push(m),
+    exit: (m) => calls.push(m),
+    error: (m) => calls.push(m),
+    pong: (m) => calls.push(m),
+  };
+  return { handlers, calls };
+}
+
+describe("dispatchClientMessage", () => {
+  it("routes resize to its handler with the parsed payload", () => {
+    const { handlers, calls } = recordingClientHandlers();
+    dispatchClientMessage('{"t":"resize","cols":120,"rows":40}', handlers);
+    expect(calls).toEqual([{ t: "resize", cols: 120, rows: 40 }]);
+  });
+
+  it("routes ping to its handler with the parsed payload", () => {
+    const { handlers, calls } = recordingClientHandlers();
+    dispatchClientMessage('{"t":"ping","ts":12345}', handlers);
+    expect(calls).toEqual([{ t: "ping", ts: 12345 }]);
+  });
+
+  it("routes editor-open to its handler with the parsed payload", () => {
+    const { handlers, calls } = recordingClientHandlers();
+    dispatchClientMessage('{"t":"editor-open","content":"buffer\\n"}', handlers);
+    expect(calls).toEqual([{ t: "editor-open", content: "buffer\n" }]);
+  });
+
+  it("passes a ProtocolError to onInvalid on malformed JSON", () => {
+    const { handlers, calls } = recordingClientHandlers();
+    const errors: ProtocolError[] = [];
+    dispatchClientMessage("not json", handlers, (error) => errors.push(error));
+    expect(calls).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(ProtocolError);
+  });
+
+  it("passes a ProtocolError to onInvalid on schema mismatch", () => {
+    const { handlers, calls } = recordingClientHandlers();
+    const errors: ProtocolError[] = [];
+    dispatchClientMessage('{"t":"resize","cols":1}', handlers, (error) => errors.push(error));
+    expect(calls).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(ProtocolError);
+  });
+
+  it("passes a ProtocolError to onInvalid on unknown message type", () => {
+    const { handlers, calls } = recordingClientHandlers();
+    const errors: ProtocolError[] = [];
+    dispatchClientMessage('{"t":"unknown"}', handlers, (error) => errors.push(error));
+    expect(calls).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(ProtocolError);
+  });
+
+  it("swallows invalid frames silently when onInvalid is omitted", () => {
+    for (const raw of ["not json", '{"t":"resize","cols":1}', '{"t":"unknown"}']) {
+      const { handlers, calls } = recordingClientHandlers();
+      expect(() => dispatchClientMessage(raw, handlers)).not.toThrow();
+      expect(calls).toEqual([]);
+    }
+  });
+
+  it("propagates handler errors without calling onInvalid", () => {
+    const thrown = new ProtocolError("handler failed");
+    const { handlers } = recordingClientHandlers();
+    const errors: ProtocolError[] = [];
+    handlers.resize = () => {
+      throw thrown;
+    };
+
+    expect(() =>
+      dispatchClientMessage('{"t":"resize","cols":120,"rows":40}', handlers, (error) => errors.push(error)),
+    ).toThrow(thrown);
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("dispatchServerMessage", () => {
+  it("routes hello to its handler", () => {
+    const { handlers, calls } = recordingServerHandlers();
+    dispatchServerMessage('{"t":"hello"}', handlers);
+    expect(calls).toEqual([{ t: "hello" }]);
+  });
+
+  it("routes exit to its handler with the parsed payload", () => {
+    const { handlers, calls } = recordingServerHandlers();
+    dispatchServerMessage('{"t":"exit","code":0}', handlers);
+    expect(calls).toEqual([{ t: "exit", code: 0 }]);
+  });
+
+  it("routes error to its handler with the parsed payload", () => {
+    const { handlers, calls } = recordingServerHandlers();
+    dispatchServerMessage('{"t":"error","message":"boom"}', handlers);
+    expect(calls).toEqual([{ t: "error", message: "boom" }]);
+  });
+
+  it("routes pong to its handler with the parsed payload", () => {
+    const { handlers, calls } = recordingServerHandlers();
+    dispatchServerMessage('{"t":"pong","ts":999}', handlers);
+    expect(calls).toEqual([{ t: "pong", ts: 999 }]);
+  });
+
+  it("passes a ProtocolError to onInvalid on malformed JSON", () => {
+    const { handlers, calls } = recordingServerHandlers();
+    const errors: ProtocolError[] = [];
+    dispatchServerMessage("not json", handlers, (error) => errors.push(error));
+    expect(calls).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(ProtocolError);
+  });
+
+  it("passes a ProtocolError to onInvalid on schema mismatch", () => {
+    const { handlers, calls } = recordingServerHandlers();
+    const errors: ProtocolError[] = [];
+    dispatchServerMessage('{"t":"exit"}', handlers, (error) => errors.push(error));
+    expect(calls).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(ProtocolError);
+  });
+
+  it("passes a ProtocolError to onInvalid on unknown message type", () => {
+    const { handlers, calls } = recordingServerHandlers();
+    const errors: ProtocolError[] = [];
+    dispatchServerMessage('{"t":"unknown"}', handlers, (error) => errors.push(error));
+    expect(calls).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(ProtocolError);
+  });
+
+  it("swallows invalid frames silently when onInvalid is omitted", () => {
+    for (const raw of ["not json", '{"t":"exit"}', '{"t":"unknown"}']) {
+      const { handlers, calls } = recordingServerHandlers();
+      expect(() => dispatchServerMessage(raw, handlers)).not.toThrow();
+      expect(calls).toEqual([]);
+    }
+  });
+
+  it("propagates handler errors without calling onInvalid", () => {
+    const thrown = new Error("handler failed");
+    const { handlers } = recordingServerHandlers();
+    const errors: ProtocolError[] = [];
+    handlers.hello = () => {
+      throw thrown;
+    };
+
+    expect(() => dispatchServerMessage('{"t":"hello"}', handlers, (error) => errors.push(error))).toThrow(thrown);
+    expect(errors).toEqual([]);
   });
 });

--- a/protocol/messages.ts
+++ b/protocol/messages.ts
@@ -88,3 +88,92 @@ export function parseClientMessage(json: string): ClientMessage {
 export function parseServerMessage(json: string): ServerMessage {
   return parseMessage(json, ServerMessageSchema, "server");
 }
+
+/**
+ * Exhaustive handler map for client messages, keyed by the `t` discriminant.
+ * Every message type must be handled (use an explicit no-op to ignore one);
+ * adding a member to {@link ClientMessage} then fails to compile at each call
+ * site until it is handled.
+ */
+type MessageHandlers<T extends { t: string }> = { [M in T as M["t"]]: (message: M) => void };
+
+export type ClientMessageHandlers = MessageHandlers<ClientMessage>;
+
+/** Exhaustive handler map for server messages. See {@link ClientMessageHandlers}. */
+export type ServerMessageHandlers = MessageHandlers<ServerMessage>;
+
+/**
+ * Parse a raw client frame and route it to the matching handler. Malformed
+ * frames are surfaced via `onInvalid` (when given) and otherwise swallowed; any
+ * non-{@link ProtocolError} is rethrown so real bugs are not hidden.
+ */
+function parseForDispatch<T>(
+  raw: string,
+  parse: (json: string) => T,
+  onInvalid?: (error: ProtocolError) => void,
+): T | undefined {
+  try {
+    return parse(raw);
+  } catch (error) {
+    if (error instanceof ProtocolError) {
+      onInvalid?.(error);
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+export function dispatchClientMessage(
+  raw: string,
+  handlers: ClientMessageHandlers,
+  onInvalid?: (error: ProtocolError) => void,
+): void {
+  const message = parseForDispatch(raw, parseClientMessage, onInvalid);
+  if (!message) return;
+  switch (message.t) {
+    case "resize":
+      handlers.resize(message);
+      return;
+    case "ping":
+      handlers.ping(message);
+      return;
+    case "editor-open":
+      handlers["editor-open"](message);
+      return;
+    default: {
+      const _exhaustive: never = message;
+      throw new ProtocolError(`Unhandled client message: ${(_exhaustive as { t: string }).t}`);
+    }
+  }
+}
+
+/**
+ * Parse a raw server frame and route it to the matching handler. See
+ * {@link dispatchClientMessage} for the error-handling contract.
+ */
+export function dispatchServerMessage(
+  raw: string,
+  handlers: ServerMessageHandlers,
+  onInvalid?: (error: ProtocolError) => void,
+): void {
+  const message = parseForDispatch(raw, parseServerMessage, onInvalid);
+  if (!message) return;
+  switch (message.t) {
+    case "hello":
+      handlers.hello(message);
+      return;
+    case "exit":
+      handlers.exit(message);
+      return;
+    case "error":
+      handlers.error(message);
+      return;
+    case "pong":
+      handlers.pong(message);
+      return;
+    default: {
+      const _exhaustive: never = message;
+      throw new ProtocolError(`Unhandled server message: ${(_exhaustive as { t: string }).t}`);
+    }
+  }
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -38,24 +38,168 @@ export interface ServerOptions {
   maxPayloadLength?: number;
 }
 
-type WsData = { kind: "main" } | { kind: "editor" };
+/**
+ * One end of a WebSocket route (`/ws` or `/editor-ws`). Each channel owns its
+ * own client registry and translates raw frames into manager calls, so the
+ * top-level handlers route by `ws.data.channel` instead of branching on a kind
+ * discriminant. The resolved channel is stored on `ws.data` at upgrade time.
+ */
+interface Channel {
+  open(ws: ServerWebSocket<WsData>): void;
+  message(ws: ServerWebSocket<WsData>, data: string | Buffer): void;
+  close(ws: ServerWebSocket<WsData>): void;
+  /** Notify (optionally) and close every connection on this channel. */
+  closeAll(message?: ServerMessage): void;
+}
+
+interface WsData {
+  channel: Channel;
+}
+
+function serializeServerMessage(message: ServerMessage): string {
+  return JSON.stringify(message);
+}
+
+function sendServerMessage(ws: ServerWebSocket<WsData>, message: ServerMessage): void {
+  ws.send(serializeServerMessage(message));
+}
+
+function sendPong(ws: ServerWebSocket<WsData>, message: PingMessage): void {
+  sendServerMessage(ws, { t: "pong", ts: message.ts });
+}
+
+/**
+ * Close every socket, optionally sending one final control message first. Does
+ * not mutate any registry — the `close` handler owns deletion (and the editor
+ * teardown), so closing here and removing there keeps teardown exactly-once.
+ */
+function closeAllSockets(sockets: Iterable<ServerWebSocket<WsData>>, message?: ServerMessage): void {
+  const serializedMessage = message ? serializeServerMessage(message) : undefined;
+  for (const ws of sockets) {
+    if (serializedMessage) ws.send(serializedMessage);
+    ws.close();
+  }
+}
+
+function createMainChannel(session: SessionManager): Channel {
+  const clients = new Map<ServerWebSocket<WsData>, ClientConnection>();
+  return {
+    open(ws) {
+      try {
+        const client: ClientConnection = {
+          send(data: Uint8Array) {
+            ws.send(data);
+          },
+        };
+        const replayData = session.connect(client);
+        clients.set(ws, client);
+
+        sendServerMessage(ws, { t: "hello" });
+
+        if (replayData.length > 0) {
+          ws.send(replayData);
+        }
+      } catch {
+        ws.close(1008, "Connection rejected");
+      }
+    },
+    message(ws, data) {
+      if (typeof data !== "string") {
+        session.write(new Uint8Array(data));
+        return;
+      }
+      // No onInvalid: malformed control frames on the main channel are
+      // swallowed silently (unchanged behavior).
+      dispatchClientMessage(data, {
+        resize: (m) => session.resize(m.cols, m.rows),
+        ping: (m) => sendPong(ws, m),
+        "editor-open": () => {}, // ignored on the main terminal channel
+      });
+    },
+    close(ws) {
+      const client = clients.get(ws);
+      if (!client) return;
+      session.disconnect(client);
+      clients.delete(ws);
+    },
+    closeAll(message) {
+      closeAllSockets(clients.keys(), message);
+    },
+  };
+}
+
+function createEditorChannel(editor: EditorSessionManager): Channel {
+  const clients = new Map<ServerWebSocket<WsData>, EditorClient>();
+  return {
+    open(ws) {
+      // The editor PTY is launched lazily, when the client sends `editor-open`
+      // carrying the buffer text. Connecting alone only registers the client.
+      const client: EditorClient = {
+        send(data: Uint8Array) {
+          ws.send(data);
+        },
+        notify(message: ServerMessage) {
+          sendServerMessage(ws, message);
+        },
+        close() {
+          ws.close();
+        },
+      };
+      clients.set(ws, client);
+    },
+    message(ws, data) {
+      const client = clients.get(ws);
+      if (!client) return;
+      if (typeof data !== "string") {
+        editor.write(client, new Uint8Array(data));
+        return;
+      }
+      dispatchClientMessage(
+        data,
+        {
+          resize: (m) => editor.resize(client, m.cols, m.rows),
+          ping: (m) => sendPong(ws, m),
+          "editor-open": (m) => {
+            void editor.open(client, m.content);
+          },
+        },
+        // A malformed editor control payload (e.g. a type mismatch) would
+        // otherwise be dropped silently, leaving the overlay stuck connecting.
+        () => {
+          client.notify({ t: "error", message: "Invalid editor request" });
+          client.close();
+        },
+      );
+    },
+    close(ws) {
+      const client = clients.get(ws);
+      if (!client) return;
+      editor.disconnect(client);
+      clients.delete(ws);
+    },
+    closeAll(message) {
+      closeAllSockets(clients.keys(), message);
+    },
+  };
+}
 
 export function createServer(options: ServerOptions) {
-  const wsClients = new Map<ServerWebSocket<WsData>, ClientConnection>();
-  const editorClients = new Map<ServerWebSocket<WsData>, EditorClient>();
+  const mainChannel = createMainChannel(options.session);
+  const editorChannel = options.editor ? createEditorChannel(options.editor) : undefined;
+
+  const channelFor = (pathname: string): Channel | undefined => {
+    if (pathname === "/ws") return mainChannel;
+    if (pathname === "/editor-ws") return editorChannel; // undefined when no editor
+    return undefined;
+  };
 
   options.session.onExit((code) => {
-    for (const ws of wsClients.keys()) {
-      ws.send(JSON.stringify({ t: "exit", code } satisfies ServerMessage));
-      ws.close();
-    }
+    mainChannel.closeAll({ t: "exit", code });
     // Tear down any open editor overlay too: otherwise its PTY and temp file
     // stay alive waiting on a client disconnect that may never come. Closing is
     // enough — the `close` handler runs `disconnect()` and removes the entry, so
     // teardown happens exactly once (mirroring the main-client path above).
-    for (const ws of editorClients.keys()) {
-      ws.close();
-    }
+    editorChannel?.closeAll();
   });
 
   const fetch = (
@@ -74,139 +218,21 @@ export function createServer(options: ServerOptions) {
       return new Response(asset.body, { headers });
     }
 
-    if (url.pathname === "/ws") {
-      if (!isValidToken(url, options.token)) {
-        return new Response("Forbidden", { status: 403 });
-      }
-      const upgraded = server.upgrade(req, { data: { kind: "main" } });
-      if (upgraded) return undefined;
-      return new Response("WebSocket upgrade failed", { status: 500 });
+    const channel = channelFor(url.pathname);
+    if (!channel) return new Response("Not Found", { status: 404 });
+
+    if (!isValidToken(url, options.token)) {
+      return new Response("Forbidden", { status: 403 });
     }
-
-    if (url.pathname === "/editor-ws") {
-      if (!options.editor) {
-        return new Response("Not Found", { status: 404 });
-      }
-      if (!isValidToken(url, options.token)) {
-        return new Response("Forbidden", { status: 403 });
-      }
-      const upgraded = server.upgrade(req, { data: { kind: "editor" } });
-      if (upgraded) return undefined;
-      return new Response("WebSocket upgrade failed", { status: 500 });
-    }
-
-    return new Response("Not Found", { status: 404 });
-  };
-
-  const sendPong = (ws: ServerWebSocket<WsData>, message: PingMessage): void => {
-    ws.send(JSON.stringify({ t: "pong", ts: message.ts } satisfies ServerMessage));
-  };
-
-  const registerEditorClient = (ws: ServerWebSocket<WsData>): void => {
-    const editor = options.editor;
-    if (!editor) {
-      ws.close();
-      return;
-    }
-    // The editor PTY is launched lazily, when the client sends `editor-open`
-    // carrying the buffer text. Connecting alone only registers the client.
-    const client: EditorClient = {
-      send(data: Uint8Array) {
-        ws.send(data);
-      },
-      notify(message: ServerMessage) {
-        ws.send(JSON.stringify(message));
-      },
-      close() {
-        ws.close();
-      },
-    };
-    editorClients.set(ws, client);
-  };
-
-  const messageEditor = (ws: ServerWebSocket<WsData>, data: string | Buffer): void => {
-    const editor = options.editor;
-    const client = editorClients.get(ws);
-    if (!editor || !client) return;
-    if (typeof data !== "string") {
-      editor.write(client, new Uint8Array(data));
-      return;
-    }
-    dispatchClientMessage(
-      data,
-      {
-        resize: (m) => editor.resize(client, m.cols, m.rows),
-        ping: (m) => sendPong(ws, m),
-        "editor-open": (m) => {
-          void editor.open(client, m.content);
-        },
-      },
-      // A malformed editor control payload (e.g. a type mismatch) would
-      // otherwise be dropped silently, leaving the overlay stuck connecting.
-      () => {
-        client.notify({ t: "error", message: "Invalid editor request" });
-        client.close();
-      },
-    );
+    const upgraded = server.upgrade(req, { data: { channel } });
+    if (upgraded) return undefined;
+    return new Response("WebSocket upgrade failed", { status: 500 });
   };
 
   const websocket = {
-    open(ws: ServerWebSocket<WsData>) {
-      if (ws.data.kind === "editor") {
-        registerEditorClient(ws);
-        return;
-      }
-      try {
-        const client: ClientConnection = {
-          send(data: Uint8Array) {
-            ws.send(data);
-          },
-        };
-        const replayData = options.session.connect(client);
-        wsClients.set(ws, client);
-
-        ws.send(JSON.stringify({ t: "hello" } satisfies ServerMessage));
-
-        if (replayData.length > 0) {
-          ws.send(replayData);
-        }
-      } catch {
-        ws.close(1008, "Connection rejected");
-      }
-    },
-
-    message(ws: ServerWebSocket<WsData>, data: string | Buffer) {
-      if (ws.data.kind === "editor") {
-        messageEditor(ws, data);
-        return;
-      }
-      if (typeof data !== "string") {
-        options.session.write(new Uint8Array(data));
-      } else {
-        // No onInvalid: malformed control frames on the main channel are
-        // swallowed silently (unchanged behavior).
-        dispatchClientMessage(data, {
-          resize: (m) => options.session.resize(m.cols, m.rows),
-          ping: (m) => sendPong(ws, m),
-          "editor-open": () => {}, // ignored on the main terminal channel
-        });
-      }
-    },
-
-    close(ws: ServerWebSocket<WsData>) {
-      if (ws.data.kind === "editor") {
-        const client = editorClients.get(ws);
-        if (client) {
-          options.editor?.disconnect(client);
-          editorClients.delete(ws);
-        }
-        return;
-      }
-      const client = wsClients.get(ws);
-      if (!client) return;
-      options.session.disconnect(client);
-      wsClients.delete(ws);
-    },
+    open: (ws: ServerWebSocket<WsData>) => ws.data.channel.open(ws),
+    message: (ws: ServerWebSocket<WsData>, data: string | Buffer) => ws.data.channel.message(ws, data),
+    close: (ws: ServerWebSocket<WsData>) => ws.data.channel.close(ws),
 
     // Carried on the handler so every Bun.serve() caller (prod and tests)
     // enforces the same inbound frame limit without threading it separately.

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from "bun";
 import type { EditorClient, EditorSessionManager } from "../editor/editor-session-manager.ts";
-import { parseClientMessage, type ServerMessage } from "../protocol/messages.ts";
+import { dispatchClientMessage, type PingMessage, type ServerMessage } from "../protocol/messages.ts";
 import { isValidToken, validateRequest } from "../security/middleware.ts";
 import type { ClientConnection, SessionManager } from "../session/session-manager.ts";
 
@@ -98,33 +98,8 @@ export function createServer(options: ServerOptions) {
     return new Response("Not Found", { status: 404 });
   };
 
-  const handleControlMessage = (
-    ws: ServerWebSocket<WsData>,
-    raw: string,
-    handlers: {
-      onResize: (cols: number, rows: number) => void;
-      onEditorOpen?: (content: string) => void;
-      onInvalid?: () => void;
-    },
-  ): void => {
-    try {
-      const msg = parseClientMessage(raw);
-      switch (msg.t) {
-        case "resize":
-          handlers.onResize(msg.cols, msg.rows);
-          break;
-        case "ping":
-          ws.send(JSON.stringify({ t: "pong", ts: msg.ts } satisfies ServerMessage));
-          break;
-        case "editor-open":
-          // Editor launch requests are valid only when the route supplies a handler.
-          handlers.onEditorOpen?.(msg.content);
-          break;
-      }
-    } catch {
-      // invalid protocol message; let the route decide whether to surface it
-      handlers.onInvalid?.();
-    }
+  const sendPong = (ws: ServerWebSocket<WsData>, message: PingMessage): void => {
+    ws.send(JSON.stringify({ t: "pong", ts: message.ts } satisfies ServerMessage));
   };
 
   const registerEditorClient = (ws: ServerWebSocket<WsData>): void => {
@@ -157,18 +132,22 @@ export function createServer(options: ServerOptions) {
       editor.write(client, new Uint8Array(data));
       return;
     }
-    handleControlMessage(ws, data, {
-      onResize: (cols, rows) => editor.resize(client, cols, rows),
-      onEditorOpen: (content) => {
-        void editor.open(client, content);
+    dispatchClientMessage(
+      data,
+      {
+        resize: (m) => editor.resize(client, m.cols, m.rows),
+        ping: (m) => sendPong(ws, m),
+        "editor-open": (m) => {
+          void editor.open(client, m.content);
+        },
       },
       // A malformed editor control payload (e.g. a type mismatch) would
       // otherwise be dropped silently, leaving the overlay stuck connecting.
-      onInvalid: () => {
+      () => {
         client.notify({ t: "error", message: "Invalid editor request" });
         client.close();
       },
-    });
+    );
   };
 
   const websocket = {
@@ -204,7 +183,13 @@ export function createServer(options: ServerOptions) {
       if (typeof data !== "string") {
         options.session.write(new Uint8Array(data));
       } else {
-        handleControlMessage(ws, data, { onResize: (cols, rows) => options.session.resize(cols, rows) });
+        // No onInvalid: malformed control frames on the main channel are
+        // swallowed silently (unchanged behavior).
+        dispatchClientMessage(data, {
+          resize: (m) => options.session.resize(m.cols, m.rows),
+          ping: (m) => sendPong(ws, m),
+          "editor-open": () => {}, // ignored on the main terminal channel
+        });
       }
     },
 

--- a/web/editor-overlay.ts
+++ b/web/editor-overlay.ts
@@ -1,24 +1,24 @@
 import { FitAddon, Terminal } from "ghostty-web";
-import { createGhosttyTerminal, type GhosttyAdapterResult, type GhosttyTerminalAddon } from "./ghostty-adapter.ts";
-import type { ConnectionState, TerminalHandle } from "./terminal.ts";
+import { createGhosttyTerminal, type GhosttyAdapterResult } from "./ghostty-adapter.ts";
+import type { TerminalHandle } from "./terminal.ts";
+import {
+  type BindableClient,
+  type BindableFitAddon,
+  bindClientToTerminal,
+  type TerminalBinding,
+} from "./terminal-binding.ts";
 import { TerminalClient } from "./terminal-client.ts";
 
-export interface EditorOverlayClient {
+export interface EditorOverlayClient extends BindableClient {
   connect(): void;
   disconnect(): void;
   /** Send the editor-open request (with buffer content) once the socket opens. */
   requestOpen(content: string): void;
-  sendInput(data: Uint8Array | ArrayBuffer): void;
-  sendResize(cols: number, rows: number): void;
-  onStateChange(callback: (state: ConnectionState) => void): void;
   onExit(callback: (code: number) => void): void;
   onError(callback: (message: string) => void): void;
 }
 
-export interface EditorOverlayFitAddon extends GhosttyTerminalAddon {
-  fit(): void;
-  observeResize(): void;
-}
+export type EditorOverlayFitAddon = BindableFitAddon;
 
 export interface EditorOverlayOptions {
   /** The full-screen overlay container (toggled via `data-active`). */
@@ -90,41 +90,19 @@ export class EditorOverlay {
 
     try {
       const createAdapter = this.options.createAdapter ?? defaultCreateAdapter;
-      this.adapter = await createAdapter(this.options.surface, this.options.terminalOptions);
+      const adapter = await createAdapter(this.options.surface, this.options.terminalOptions);
+      this.adapter = adapter;
 
       const createClient = this.options.createClient ?? defaultCreateClient;
-      const client = createClient(this.adapter.handle, this.options.wsUrl);
+      const client = createClient(adapter.handle, this.options.wsUrl);
       this.client = client;
 
-      const encoder = new TextEncoder();
-      this.disposers.push(
-        this.adapter.onData((data) => {
-          client.sendInput(encoder.encode(data));
-        }),
-      );
-
       const fitAddon = (this.options.createFitAddon ?? defaultCreateFitAddon)();
-      this.adapter.loadAddon(fitAddon);
-      this.disposers.push(fitAddon);
-
-      let lastCols = 0;
-      let lastRows = 0;
-      this.disposers.push(
-        this.adapter.onResize((cols, rows) => {
-          lastCols = cols;
-          lastRows = rows;
-          client.sendResize(cols, rows);
-        }),
-      );
+      const binding: TerminalBinding = bindClientToTerminal({ adapter, client, fitAddon });
+      this.disposers.push(binding);
 
       client.onStateChange((state) => {
-        if (state === "connected") {
-          fitAddon.fit();
-          if (lastCols > 0 && lastRows > 0) {
-            client.sendResize(lastCols, lastRows);
-          }
-          this.adapter?.focus();
-        } else if (state === "disconnected" && this.active) {
+        if (state === "disconnected" && this.active) {
           this.teardown();
         }
       });
@@ -137,9 +115,6 @@ export class EditorOverlay {
         this.reportError(message);
         this.teardown();
       });
-
-      fitAddon.fit();
-      fitAddon.observeResize();
 
       client.requestOpen(content);
       client.connect();

--- a/web/main.ts
+++ b/web/main.ts
@@ -4,6 +4,7 @@ import { EditorOverlay } from "./editor-overlay.ts";
 import { createGhosttyTerminal } from "./ghostty-adapter.ts";
 import { formatTabTitle } from "./tab-title.ts";
 import type { ConnectionState } from "./terminal.ts";
+import { bindClientToTerminal } from "./terminal-binding.ts";
 import { TerminalClient } from "./terminal-client.ts";
 
 const DEFAULT_FONT_SIZE = 14;
@@ -79,15 +80,13 @@ async function main() {
     terminalOptions.fontFamily = fontFamily;
   }
 
-  const { handle, onData, onResize, loadAddon, focus, getBufferText } = await createGhosttyTerminal(
+  const adapter = await createGhosttyTerminal(
     container,
     { init, createTerminal: (opts) => new Terminal(opts) },
     terminalOptions,
   );
 
-  const client = new TerminalClient({ terminal: handle, wsUrl });
-  let lastCols = 0;
-  let lastRows = 0;
+  const client = new TerminalClient({ terminal: adapter.handle, wsUrl });
   let connectionState: ConnectionState = "disconnected";
   let terminalTitle: string | null = null;
 
@@ -95,26 +94,11 @@ async function main() {
     document.title = formatTabTitle(connectionState, terminalTitle);
   };
 
-  onResize((cols, rows) => {
-    lastCols = cols;
-    lastRows = rows;
-    client.sendResize(cols, rows);
-  });
-
-  const fitAddon = new FitAddon();
-  loadAddon(fitAddon);
-
-  fitAddon.fit();
-  fitAddon.observeResize();
-
   updateDocumentTitle();
 
   client.onStateChange((state) => {
     connectionState = state;
     updateDocumentTitle();
-    if (state === "connected" && lastCols > 0 && lastRows > 0) {
-      client.sendResize(lastCols, lastRows);
-    }
   });
 
   client.onTitleChange((title) => {
@@ -134,7 +118,7 @@ async function main() {
       surface: editorOverlaySurface,
       wsUrl: editorWsUrl,
       terminalOptions,
-      onClosed: () => focus(),
+      onClosed: () => adapter.focus(),
       onError: showToast,
     });
   }
@@ -155,21 +139,26 @@ async function main() {
         }
         // Snapshot the main terminal buffer now; the overlay seeds the editor
         // PTY's temporary file with this text.
-        void editorOverlay.open(getBufferText());
+        void editorOverlay.open(adapter.getBufferText());
       }
     },
     { capture: true },
   );
 
-  const encoder = new TextEncoder();
-  onData((data) => {
-    // Keep input out of the main PTY while the editor overlay is focused.
-    if (editorOverlay?.isActive()) return;
-    client.sendInput(encoder.encode(data));
+  // Bind after the overlay exists: this predicate reads it to mute input and
+  // avoid stealing focus while the overlay is focused.
+  const canUseMainTerminal = () => !editorOverlay?.isActive();
+  const fitAddon = new FitAddon();
+  bindClientToTerminal({
+    adapter,
+    client,
+    fitAddon,
+    shouldSendInput: canUseMainTerminal,
+    shouldFocus: canUseMainTerminal,
   });
 
   client.connect();
-  focus();
+  adapter.focus();
 }
 
 main().catch(console.error);

--- a/web/terminal-binding.test.ts
+++ b/web/terminal-binding.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { GhosttyTerminalAddon } from "./ghostty-adapter.ts";
+import type { ConnectionState } from "./terminal.ts";
+import {
+  type BindableClient,
+  type BindableFitAddon,
+  bindClientToTerminal,
+  type TerminalAdapter,
+} from "./terminal-binding.ts";
+
+function makeAdapter() {
+  let dataCallback: ((data: string) => void) | null = null;
+  let resizeCallback: ((cols: number, rows: number) => void) | null = null;
+  const dataDispose = mock(() => {});
+  const resizeDispose = mock(() => {});
+  const focus = mock(() => {});
+  const loadAddon = mock((_addon: GhosttyTerminalAddon) => {});
+  const adapter: TerminalAdapter = {
+    onData(callback) {
+      dataCallback = callback;
+      return { dispose: dataDispose };
+    },
+    onResize(callback) {
+      resizeCallback = callback;
+      return { dispose: resizeDispose };
+    },
+    loadAddon,
+    focus,
+  };
+  return {
+    adapter,
+    focus,
+    loadAddon,
+    dataDispose,
+    resizeDispose,
+    fireData(data: string) {
+      dataCallback?.(data);
+    },
+    fireResize(cols: number, rows: number) {
+      resizeCallback?.(cols, rows);
+    },
+  };
+}
+
+function makeClient() {
+  const stateCallbacks: Array<(state: ConnectionState) => void> = [];
+  const sentInputs: Uint8Array[] = [];
+  const sentResizes: Array<{ cols: number; rows: number }> = [];
+  const client: BindableClient = {
+    sendInput(data) {
+      sentInputs.push(data instanceof Uint8Array ? data : new Uint8Array(data));
+    },
+    sendResize(cols, rows) {
+      sentResizes.push({ cols, rows });
+    },
+    onStateChange(callback) {
+      stateCallbacks.push(callback);
+    },
+  };
+  return {
+    client,
+    sentInputs,
+    sentResizes,
+    emitState(state: ConnectionState) {
+      for (const callback of stateCallbacks) callback(state);
+    },
+  };
+}
+
+function makeFitAddon(): BindableFitAddon {
+  return {
+    activate() {},
+    dispose: mock(() => {}),
+    fit: mock(() => {}),
+    observeResize: mock(() => {}),
+  };
+}
+
+describe("bindClientToTerminal", () => {
+  it("sends terminal input as encoded bytes", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    bindClientToTerminal({ adapter: adapterHarness.adapter, client: clientHarness.client, fitAddon: makeFitAddon() });
+
+    adapterHarness.fireData("abc");
+
+    expect(clientHarness.sentInputs).toEqual([new TextEncoder().encode("abc")]);
+  });
+
+  it("drops input when shouldSendInput returns false and sends when it returns true", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    let allow = false;
+    bindClientToTerminal({
+      adapter: adapterHarness.adapter,
+      client: clientHarness.client,
+      fitAddon: makeFitAddon(),
+      shouldSendInput: () => allow,
+    });
+
+    adapterHarness.fireData("muted");
+    expect(clientHarness.sentInputs).toHaveLength(0);
+
+    allow = true;
+    adapterHarness.fireData("live");
+    expect(clientHarness.sentInputs).toEqual([new TextEncoder().encode("live")]);
+  });
+
+  it("always sends input when no guard is provided", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    bindClientToTerminal({ adapter: adapterHarness.adapter, client: clientHarness.client, fitAddon: makeFitAddon() });
+
+    adapterHarness.fireData("x");
+    adapterHarness.fireData("y");
+
+    expect(clientHarness.sentInputs).toHaveLength(2);
+  });
+
+  it("tracks and forwards resize events", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    bindClientToTerminal({ adapter: adapterHarness.adapter, client: clientHarness.client, fitAddon: makeFitAddon() });
+
+    adapterHarness.fireResize(120, 40);
+
+    expect(clientHarness.sentResizes).toEqual([{ cols: 120, rows: 40 }]);
+  });
+
+  it("loads the fit addon and performs an initial fit and observeResize", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    const fitAddon = makeFitAddon();
+    bindClientToTerminal({ adapter: adapterHarness.adapter, client: clientHarness.client, fitAddon });
+
+    expect(adapterHarness.loadAddon).toHaveBeenCalledWith(fitAddon);
+    expect(fitAddon.fit).toHaveBeenCalledTimes(1);
+    expect(fitAddon.observeResize).toHaveBeenCalledTimes(1);
+  });
+
+  it("fits, resends the latest size, and focuses on connect", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    const fitAddon = makeFitAddon();
+    bindClientToTerminal({ adapter: adapterHarness.adapter, client: clientHarness.client, fitAddon });
+
+    adapterHarness.fireResize(100, 30);
+    clientHarness.sentResizes.length = 0;
+    (fitAddon.fit as ReturnType<typeof mock>).mockClear();
+
+    clientHarness.emitState("connected");
+
+    expect(fitAddon.fit).toHaveBeenCalledTimes(1);
+    expect(clientHarness.sentResizes).toEqual([{ cols: 100, rows: 30 }]);
+    expect(adapterHarness.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not resend size on connect when no resize was seen", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    const fitAddon = makeFitAddon();
+    bindClientToTerminal({ adapter: adapterHarness.adapter, client: clientHarness.client, fitAddon });
+
+    clientHarness.emitState("connected");
+
+    expect(fitAddon.fit).toHaveBeenCalled();
+    expect(adapterHarness.focus).toHaveBeenCalledTimes(1);
+    expect(clientHarness.sentResizes).toHaveLength(0);
+  });
+
+  it("skips connect-time focus when shouldFocus returns false", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    const fitAddon = makeFitAddon();
+    bindClientToTerminal({
+      adapter: adapterHarness.adapter,
+      client: clientHarness.client,
+      fitAddon,
+      shouldFocus: () => false,
+    });
+
+    adapterHarness.fireResize(100, 30);
+    clientHarness.sentResizes.length = 0;
+    (fitAddon.fit as ReturnType<typeof mock>).mockClear();
+
+    clientHarness.emitState("connected");
+
+    expect(fitAddon.fit).toHaveBeenCalledTimes(1);
+    expect(clientHarness.sentResizes).toEqual([{ cols: 100, rows: 30 }]);
+    expect(adapterHarness.focus).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-connected states", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    const fitAddon = makeFitAddon();
+    bindClientToTerminal({ adapter: adapterHarness.adapter, client: clientHarness.client, fitAddon });
+    (fitAddon.fit as ReturnType<typeof mock>).mockClear();
+
+    clientHarness.emitState("connecting");
+    clientHarness.emitState("disconnected");
+
+    expect(fitAddon.fit).not.toHaveBeenCalled();
+    expect(adapterHarness.focus).not.toHaveBeenCalled();
+    expect(clientHarness.sentResizes).toHaveLength(0);
+  });
+
+  it("disposes the data sub, resize sub, and fit addon on dispose", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    const fitAddon = makeFitAddon();
+    const binding = bindClientToTerminal({
+      adapter: adapterHarness.adapter,
+      client: clientHarness.client,
+      fitAddon,
+    });
+
+    binding.dispose();
+
+    expect(adapterHarness.dataDispose).toHaveBeenCalledTimes(1);
+    expect(adapterHarness.resizeDispose).toHaveBeenCalledTimes(1);
+    expect(fitAddon.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores connected state changes after dispose", () => {
+    const adapterHarness = makeAdapter();
+    const clientHarness = makeClient();
+    const fitAddon = makeFitAddon();
+    const binding = bindClientToTerminal({
+      adapter: adapterHarness.adapter,
+      client: clientHarness.client,
+      fitAddon,
+    });
+
+    adapterHarness.fireResize(100, 30);
+    binding.dispose();
+    clientHarness.sentResizes.length = 0;
+    (fitAddon.fit as ReturnType<typeof mock>).mockClear();
+
+    clientHarness.emitState("connected");
+
+    expect(fitAddon.fit).not.toHaveBeenCalled();
+    expect(clientHarness.sentResizes).toHaveLength(0);
+    expect(adapterHarness.focus).not.toHaveBeenCalled();
+  });
+});

--- a/web/terminal-binding.ts
+++ b/web/terminal-binding.ts
@@ -1,0 +1,95 @@
+import type { GhosttyTerminalAddon } from "./ghostty-adapter.ts";
+import type { ConnectionState } from "./terminal.ts";
+
+/** Subset of the ghostty adapter the binding drives. */
+export interface TerminalAdapter {
+  onData(callback: (data: string) => void): { dispose(): void };
+  onResize(callback: (cols: number, rows: number) => void): { dispose(): void };
+  loadAddon(addon: GhosttyTerminalAddon): void;
+  focus(): void;
+}
+
+/** Subset of {@link TerminalClient} / {@link EditorOverlayClient} the binding drives. */
+export interface BindableClient {
+  sendInput(data: Uint8Array | ArrayBuffer): void;
+  sendResize(cols: number, rows: number): void;
+  onStateChange(callback: (state: ConnectionState) => void): void;
+}
+
+export interface BindableFitAddon extends GhosttyTerminalAddon {
+  fit(): void;
+  observeResize(): void;
+}
+
+export interface BindClientToTerminalOptions {
+  adapter: TerminalAdapter;
+  client: BindableClient;
+  fitAddon: BindableFitAddon;
+  /**
+   * When provided and it returns false, the keystroke is dropped instead of
+   * sent. The main terminal uses this to mute input while the editor overlay
+   * is focused; the overlay omits it (always sends).
+   */
+  shouldSendInput?: () => boolean;
+  /**
+   * When provided and it returns false, skip connect-time focus. The main
+   * terminal uses this to avoid stealing focus while the editor overlay is
+   * active.
+   */
+  shouldFocus?: () => boolean;
+}
+
+export interface TerminalBinding {
+  dispose(): void;
+}
+
+/**
+ * Wire a ghostty terminal adapter to a {@link TerminalClient}: forward input,
+ * track and forward resizes, install the fit addon, and on connect re-fit,
+ * resend the latest size, and focus. Both the main terminal and the editor
+ * overlay bind through here so the wiring lives—and is tested—in one place.
+ */
+export function bindClientToTerminal(options: BindClientToTerminalOptions): TerminalBinding {
+  const { adapter, client, fitAddon, shouldSendInput, shouldFocus } = options;
+  const encoder = new TextEncoder();
+
+  let disposed = false;
+  let lastCols = 0;
+  let lastRows = 0;
+
+  const dataSub = adapter.onData((data) => {
+    if (shouldSendInput && !shouldSendInput()) return;
+    client.sendInput(encoder.encode(data));
+  });
+
+  const resizeSub = adapter.onResize((cols, rows) => {
+    lastCols = cols;
+    lastRows = rows;
+    client.sendResize(cols, rows);
+  });
+
+  adapter.loadAddon(fitAddon);
+
+  client.onStateChange((state) => {
+    if (disposed || state !== "connected") return;
+    fitAddon.fit();
+    if (lastCols > 0 && lastRows > 0) {
+      client.sendResize(lastCols, lastRows);
+    }
+    if (!shouldFocus || shouldFocus()) {
+      adapter.focus();
+    }
+  });
+
+  fitAddon.fit();
+  fitAddon.observeResize();
+
+  return {
+    dispose() {
+      disposed = true;
+      dataSub.dispose();
+      resizeSub.dispose();
+      fitAddon.dispose();
+    },
+  };
+}

--- a/web/terminal-client.test.ts
+++ b/web/terminal-client.test.ts
@@ -258,28 +258,6 @@ describe("TerminalClient", () => {
     expect(titles).toEqual(["repo/kastty"]);
   });
 
-  it("extracts terminal title when OSC sequence is split across frames", async () => {
-    const terminal = new MockTerminal();
-    const titles: string[] = [];
-    const c = new TerminalClient({
-      terminal,
-      wsUrl: `ws://127.0.0.1:${server.port}`,
-    });
-    client = c;
-    c.onTitleChange((title) => titles.push(title));
-
-    c.connect();
-    await server.waitForConnection();
-    server.sendHello();
-    await waitFor(() => c.getState() === "connected");
-
-    server.sendBinary(new TextEncoder().encode("\u001b]2;repo/ka"));
-    server.sendBinary(new TextEncoder().encode("stty\u001b\\"));
-
-    await waitFor(() => titles.length > 0);
-    expect(titles).toEqual(["repo/kastty"]);
-  });
-
   it("tracks connection state transitions (connecting → connected → disconnected)", async () => {
     const terminal = new MockTerminal();
     const states: ConnectionState[] = [];

--- a/web/terminal-client.ts
+++ b/web/terminal-client.ts
@@ -1,4 +1,4 @@
-import { type EditorOpenMessage, parseServerMessage } from "../protocol/messages.ts";
+import { dispatchServerMessage, type EditorOpenMessage, type ResizeMessage } from "../protocol/messages.ts";
 import type { ConnectionState, TerminalHandle } from "./terminal.ts";
 
 export type StateChangeCallback = (state: ConnectionState) => void;
@@ -121,7 +121,7 @@ export class TerminalClient {
 
   sendResize(cols: number, rows: number): void {
     if (this.ws && this.state === "connected") {
-      this.ws.send(JSON.stringify({ t: "resize", cols, rows }));
+      this.ws.send(JSON.stringify({ t: "resize", cols, rows } satisfies ResizeMessage));
     }
   }
 
@@ -134,28 +134,21 @@ export class TerminalClient {
   }
 
   private handleControlMessage(raw: string): void {
-    try {
-      const msg = parseServerMessage(raw);
-      switch (msg.t) {
-        case "hello":
-          this.setState("connected");
-          break;
-        case "exit":
-          for (const cb of this.exitCallbacks) {
-            cb(msg.code);
-          }
-          break;
-        case "error":
-          for (const cb of this.errorCallbacks) {
-            cb(msg.message);
-          }
-          break;
-        case "pong":
-          break;
-      }
-    } catch {
-      // ignore malformed control messages
-    }
+    // No onInvalid: malformed control messages are ignored (unchanged behavior).
+    dispatchServerMessage(raw, {
+      hello: () => this.setState("connected"),
+      exit: (msg) => {
+        for (const cb of this.exitCallbacks) {
+          cb(msg.code);
+        }
+      },
+      error: (msg) => {
+        for (const cb of this.errorCallbacks) {
+          cb(msg.message);
+        }
+      },
+      pong: () => {},
+    });
   }
 
   private processTitleFromOutput(data: Uint8Array): void {

--- a/web/terminal-client.ts
+++ b/web/terminal-client.ts
@@ -1,17 +1,11 @@
 import { dispatchServerMessage, type EditorOpenMessage, type ResizeMessage } from "../protocol/messages.ts";
 import type { ConnectionState, TerminalHandle } from "./terminal.ts";
+import { TitleParser } from "./title-parser.ts";
 
 export type StateChangeCallback = (state: ConnectionState) => void;
 export type ExitCallback = (code: number) => void;
 export type TitleChangeCallback = (title: string) => void;
 export type ErrorCallback = (message: string) => void;
-
-const ESC = "\u001b";
-const ESC_CODE = 0x1b;
-const OSC_PREFIX = `${ESC}]`;
-const BEL = "\u0007";
-const ST = `${ESC}\\`;
-const MAX_TITLE_BUFFER_LENGTH = 8192;
 
 export interface TerminalClientOptions {
   wsUrl: string;
@@ -27,8 +21,7 @@ export class TerminalClient {
   private readonly exitCallbacks: ExitCallback[] = [];
   private readonly titleCallbacks: TitleChangeCallback[] = [];
   private readonly errorCallbacks: ErrorCallback[] = [];
-  private titleBuffer = "";
-  private titleDecoder = new TextDecoder();
+  private readonly titleParser = new TitleParser();
   private pendingOpenMessage: string | null = null;
 
   constructor(options: TerminalClientOptions) {
@@ -39,7 +32,7 @@ export class TerminalClient {
   connect(): void {
     if (this.ws) return;
 
-    this.resetTitleParser();
+    this.titleParser.reset();
     this.setState("connecting");
     const ws = new WebSocket(this.wsUrl);
     ws.binaryType = "arraybuffer";
@@ -68,7 +61,7 @@ export class TerminalClient {
 
     ws.addEventListener("close", () => {
       this.ws = null;
-      this.resetTitleParser();
+      this.titleParser.reset();
       this.setState("disconnected");
     });
   }
@@ -152,69 +145,10 @@ export class TerminalClient {
   }
 
   private processTitleFromOutput(data: Uint8Array): void {
-    if (this.titleBuffer.length === 0 && !data.includes(ESC_CODE)) return;
-
-    const decoded = this.titleDecoder.decode(data, { stream: true });
-    if (decoded.length === 0) return;
-    this.titleBuffer += decoded;
-
-    let cursor = 0;
-    while (true) {
-      const start = this.titleBuffer.indexOf(OSC_PREFIX, cursor);
-      if (start === -1) break;
-
-      const typeIndex = start + OSC_PREFIX.length;
-      const type = this.titleBuffer[typeIndex];
-      if ((type !== "0" && type !== "2") || this.titleBuffer[typeIndex + 1] !== ";") {
-        cursor = typeIndex + 1;
-        continue;
-      }
-
-      const titleStart = typeIndex + 2;
-      const belIndex = this.titleBuffer.indexOf(BEL, titleStart);
-      const stIndex = this.titleBuffer.indexOf(ST, titleStart);
-
-      let titleEnd = -1;
-      let terminatorLength = 0;
-      if (belIndex !== -1 && (stIndex === -1 || belIndex < stIndex)) {
-        titleEnd = belIndex;
-        terminatorLength = BEL.length;
-      } else if (stIndex !== -1) {
-        titleEnd = stIndex;
-        terminatorLength = ST.length;
-      }
-
-      if (titleEnd === -1) {
-        this.titleBuffer = this.titleBuffer.slice(start);
-        if (this.titleBuffer.length > MAX_TITLE_BUFFER_LENGTH) {
-          this.titleBuffer = this.titleBuffer.slice(-MAX_TITLE_BUFFER_LENGTH);
-        }
-        return;
-      }
-
-      const title = this.titleBuffer.slice(titleStart, titleEnd);
+    for (const title of this.titleParser.push(data)) {
       for (const cb of this.titleCallbacks) {
         cb(title);
       }
-
-      cursor = titleEnd + terminatorLength;
     }
-
-    const remaining = this.titleBuffer.slice(cursor);
-    const partialStart = remaining.lastIndexOf(OSC_PREFIX);
-    if (partialStart < 0) {
-      this.titleBuffer = "";
-      return;
-    }
-
-    this.titleBuffer = remaining.slice(partialStart);
-    if (this.titleBuffer.length > MAX_TITLE_BUFFER_LENGTH) {
-      this.titleBuffer = this.titleBuffer.slice(-MAX_TITLE_BUFFER_LENGTH);
-    }
-  }
-
-  private resetTitleParser(): void {
-    this.titleBuffer = "";
-    this.titleDecoder = new TextDecoder();
   }
 }

--- a/web/title-parser.test.ts
+++ b/web/title-parser.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { TitleParser } from "./title-parser.ts";
+
+const encoder = new TextEncoder();
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+const ST = `${ESC}\\`; // String Terminator: ESC backslash
+const OVERSIZED_TITLE = "x".repeat(100000);
+
+/** Encode a string built from ESC/BEL/ST into a single output frame. */
+function frame(text: string): Uint8Array {
+  return encoder.encode(text);
+}
+
+describe("TitleParser", () => {
+  it("extracts an OSC 2 title terminated by BEL", () => {
+    const parser = new TitleParser();
+    expect(parser.push(frame(`${ESC}]2;repo/kastty${BEL}`))).toEqual(["repo/kastty"]);
+  });
+
+  it("extracts an OSC 0 title terminated by BEL", () => {
+    const parser = new TitleParser();
+    expect(parser.push(frame(`${ESC}]0;window${BEL}`))).toEqual(["window"]);
+  });
+
+  it("extracts a title terminated by ST (ESC backslash)", () => {
+    const parser = new TitleParser();
+    expect(parser.push(frame(`${ESC}]2;via-st${ST}`))).toEqual(["via-st"]);
+  });
+
+  it("returns multiple titles found in a single chunk", () => {
+    const parser = new TitleParser();
+    expect(parser.push(frame(`${ESC}]2;first${BEL}${ESC}]2;second${BEL}`))).toEqual(["first", "second"]);
+  });
+
+  it("ignores OSC sequences other than types 0 and 2", () => {
+    const parser = new TitleParser();
+    // OSC 1 (icon name) and OSC 8 (hyperlink) must be skipped, then OSC 2 found.
+    const input = `${ESC}]1;icon${BEL}${ESC}]8;;https://example.com${BEL}${ESC}]2;real${BEL}`;
+    expect(parser.push(frame(input))).toEqual(["real"]);
+  });
+
+  it("returns no titles for a chunk without ESC", () => {
+    const parser = new TitleParser();
+    expect(parser.push(frame("plain output, no escape"))).toEqual([]);
+  });
+
+  it("buffers a sequence split across two pushes", () => {
+    const parser = new TitleParser();
+    expect(parser.push(frame(`${ESC}]2;repo/ka`))).toEqual([]);
+    expect(parser.push(frame(`stty${BEL}`))).toEqual(["repo/kastty"]);
+  });
+
+  it("buffers an OSC prefix split between ESC and bracket", () => {
+    const parser = new TitleParser();
+    expect(parser.push(frame(ESC))).toEqual([]);
+    expect(parser.push(frame(`]2;repo/kastty${BEL}`))).toEqual(["repo/kastty"]);
+  });
+
+  it("prefers the earliest terminator when both BEL and ST appear", () => {
+    const parser = new TitleParser();
+    // BEL appears before ST, so the title ends at BEL; the trailing ST text is
+    // ordinary content and yields no further title.
+    expect(parser.push(frame(`${ESC}]2;early${BEL} then ${ST}`))).toEqual(["early"]);
+  });
+
+  it("decodes a multi-byte UTF-8 title split across frame boundaries", () => {
+    const parser = new TitleParser();
+    const bytes = encoder.encode(`${ESC}]2;あ${BEL}`); // "あ" is 3 bytes in UTF-8
+    // Split inside the 3-byte "あ": prefix carries ESC ] 2 ; and its first byte.
+    const split = 5;
+    expect(parser.push(bytes.slice(0, split))).toEqual([]);
+    expect(parser.push(bytes.slice(split))).toEqual(["あ"]);
+  });
+
+  it("discards a partial sequence after reset", () => {
+    const parser = new TitleParser();
+    expect(parser.push(frame(`${ESC}]2;repo/ka`))).toEqual([]);
+    parser.reset();
+    // The buffered prefix is gone, so the completion alone yields no title.
+    expect(parser.push(frame(`stty${BEL}`))).toEqual([]);
+  });
+
+  it("stays bounded on a long unterminated sequence and recovers afterwards", () => {
+    const parser = new TitleParser();
+    // A huge unterminated OSC must not throw; a later complete sequence still parses.
+    expect(parser.push(frame(`${ESC}]2;${OVERSIZED_TITLE}`))).toEqual([]);
+    expect(parser.push(frame(`${ESC}]2;recovered${BEL}`))).toEqual(["recovered"]);
+  });
+
+  it("does not emit embedded OSC text after discarding a long unterminated sequence", () => {
+    const parser = new TitleParser();
+    const embedded = `${OVERSIZED_TITLE}${ESC}]2;fake`;
+    expect(parser.push(frame(`${ESC}]2;${embedded}`))).toEqual([]);
+    expect(parser.push(frame(BEL))).toEqual([]);
+  });
+
+  it("recovers after a long unterminated sequence is terminated", () => {
+    const parser = new TitleParser();
+    expect(parser.push(frame(`${ESC}]2;${OVERSIZED_TITLE}`))).toEqual([]);
+    expect(parser.push(frame(`${BEL}${ESC}]2;recovered${BEL}`))).toEqual(["recovered"]);
+  });
+});

--- a/web/title-parser.ts
+++ b/web/title-parser.ts
@@ -1,0 +1,90 @@
+const ESC = "\u001b";
+const ESC_CODE = 0x1b;
+const OSC_PREFIX = `${ESC}]`;
+const BEL = "\u0007";
+const ST = `${ESC}\\`;
+const MAX_TITLE_BUFFER_LENGTH = 8192;
+
+/**
+ * Streaming parser for OSC 0/2 window-title sequences in raw terminal output.
+ *
+ * Terminal output arrives as a stream of binary frames, so a title sequence
+ * (`ESC ] 0;<title> BEL` or `ESC ] 2;<title> ST`) may be split across frames.
+ * {@link push} accumulates partial sequences in an internal buffer and a
+ * streaming `TextDecoder` so multi-byte UTF-8 split across a frame boundary is
+ * decoded correctly, returning any complete titles found so far.
+ *
+ * The buffer is capped at {@link MAX_TITLE_BUFFER_LENGTH} so an unterminated
+ * sequence cannot grow without bound.
+ */
+export class TitleParser {
+  private buffer = "";
+  private decoder = new TextDecoder();
+
+  /** Feed a chunk of raw terminal output; returns any complete titles found. */
+  push(data: Uint8Array): string[] {
+    const titles: string[] = [];
+    if (this.buffer.length === 0 && !data.includes(ESC_CODE)) return titles;
+
+    const decoded = this.decoder.decode(data, { stream: true });
+    if (decoded.length === 0) return titles;
+    this.buffer += decoded;
+
+    let cursor = 0;
+    while (true) {
+      const start = this.buffer.indexOf(OSC_PREFIX, cursor);
+      if (start === -1) break;
+
+      const typeIndex = start + OSC_PREFIX.length;
+      const type = this.buffer[typeIndex];
+      if ((type !== "0" && type !== "2") || this.buffer[typeIndex + 1] !== ";") {
+        cursor = typeIndex + 1;
+        continue;
+      }
+
+      const titleStart = typeIndex + 2;
+      const belIndex = this.buffer.indexOf(BEL, titleStart);
+      const stIndex = this.buffer.indexOf(ST, titleStart);
+
+      let titleEnd = -1;
+      let terminatorLength = 0;
+      if (belIndex !== -1 && (stIndex === -1 || belIndex < stIndex)) {
+        titleEnd = belIndex;
+        terminatorLength = BEL.length;
+      } else if (stIndex !== -1) {
+        titleEnd = stIndex;
+        terminatorLength = ST.length;
+      }
+
+      if (titleEnd === -1) {
+        this.buffer = this.buffer.slice(start);
+        if (this.buffer.length > MAX_TITLE_BUFFER_LENGTH) {
+          this.buffer = "";
+        }
+        return titles;
+      }
+
+      titles.push(this.buffer.slice(titleStart, titleEnd));
+      cursor = titleEnd + terminatorLength;
+    }
+
+    const remaining = this.buffer.slice(cursor);
+    const partialStart = remaining.lastIndexOf(OSC_PREFIX);
+    if (partialStart < 0) {
+      this.buffer = remaining.endsWith(ESC) ? ESC : "";
+      return titles;
+    }
+
+    this.buffer = remaining.slice(partialStart);
+    if (this.buffer.length > MAX_TITLE_BUFFER_LENGTH) {
+      this.buffer = "";
+    }
+    return titles;
+  }
+
+  /** Reset the internal buffer and decoder (on connect/disconnect). */
+  reset(): void {
+    this.buffer = "";
+    this.decoder = new TextDecoder();
+  }
+}


### PR DESCRIPTION
## Summary

Consolidate protocol message dispatch, extract standalone modules from inline code in CLI/WebSocket/web layers, and introduce a shared `Channel` abstraction for WebSocket routes. These changes reduce duplication across the server and client, centralize the terminal-to-client wiring, and improve test coverage.

## Changes

- **protocol/messages.ts**: Add typed message dispatch (`dispatchClientMessage`, `dispatchServerMessage`) with exhaustive handler maps, eliminating redundant try/parse/switch blocks in the server and web client
- **server/app.ts**: Introduce `Channel` interface for WebSocket routes; each route (`/ws` main, `/editor-ws`) owns its lifecycle, removing `kind` discriminant branching in the handler object
- **cli/run-until-exit.ts**: Extract `runUntilExit` from `cli/run.ts` into its own module with dedicated tests
- **web/title-parser.ts**: Extract OSC 0/2 title parsing from `TerminalClient` into a standalone streaming `TitleParser` class with tests for split-frame and multi-byte scenarios
- **web/terminal-binding.ts**: Extract terminal-to-client wiring (input forwarding, resize tracking, fit addon, connect-time actions) into a shared `bindClientToTerminal` function used by both main terminal and editor overlay
- **web/main.ts, web/editor-overlay.ts**: Consume `bindClientToTerminal`; remove duplicated input/resize/focus wiring

## Motivation

These refactors eliminate duplicated dispatch and wiring patterns, making the codebase easier to test and extend. Each extracted module has its own test suite, and the typed dispatch approach ensures that adding a new message type fails to compile at every call site until handled.

## Technical Details

- `MessageHandlers<T>` uses a mapped type keyed by `t` discriminant, giving exhaustive compile-time coverage
- `parseForDispatch` separates ProtocolErrors (surfaced via optional `onInvalid` callback) from real bugs (rethrown)
- `Channel` stores a reference on `ws.data` at upgrade time, so the WebSocket handler methods delegate without branching
- `TitleParser` uses a streaming `TextDecoder` and a bounded (`MAX_TITLE_BUFFER_LENGTH`) internal buffer for split-frame and unbounded-sequence resilience
- `bindClientToTerminal` accepts optional guards (`shouldSendInput`, `shouldFocus`) for the main terminal to defer to the editor overlay

## Impact

- Affected features: WebSocket protocol handling, server WebSocket routes, terminal client (main and editor overlay), CLI process management
- Affected files: `protocol/messages.ts`, `server/app.ts`, `cli/run.ts`, `cli/run-until-exit.ts`, `web/main.ts`, `web/editor-overlay.ts`, `web/terminal-client.ts`, `web/terminal-binding.ts`, `web/title-parser.ts` (plus `.test.ts` files)
- Breaking changes: No

## Testing

1. `bun test` passes for all existing and new tests
2. Existing protocol message tests remain unchanged
3. New tests cover `dispatchClientMessage`, `dispatchServerMessage`, `TitleParser` (split frames, multi-byte, bounded buffer), `bindClientToTerminal` (input guard, resize tracking, connect-time actions, dispose), and `runUntilExit`

## Checklist

- [x] Code works as expected
- [x] Tests have been added/updated
- [x] Documentation has been updated (if necessary)
- [x] Linter and formatter have been run
- [x] Breaking changes are clearly documented

## Additional Notes

No behavioral changes are introduced; all refactors preserve the existing interface contracts.
