### PR TITLE
Align config with bun template and add CI workflows

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,20 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices",
-    ":timezone(Asia/Tokyo)",
-    "schedule:weekends"
-  ],
-  "labels": ["dependencies"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
-  },
-  "prHourlyLimit": 0,
-  "minimumReleaseAge": "3 days",
-  "internalChecksAsSuccess": true,
-  "reviewersFromCodeOwners": true,
-  "assignAutomerge": true,
+  "extends": ["github>shuymn/github-actions#main"],
   "customManagers": [
     {
       "customType": "regex",
@@ -40,26 +26,6 @@
       "depNameTemplate": "ryanoasis/nerd-fonts",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
-    }
-  ],
-  "packageRules": [
-    {
-      "description": "Group .bun-version updates",
-      "matchManagers": ["bun-version"],
-      "groupName": "bun",
-      "groupSlug": "bun"
-    },
-    {
-      "description": "Group @types/bun updates",
-      "matchPackageNames": ["@types/bun"],
-      "groupName": "bun",
-      "groupSlug": "bun"
-    },
-    {
-      "description": "Automerge minor/patch updates for non-major versions",
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": ">=1.0.0",
-      "automerge": true
     }
   ]
 }

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -1,0 +1,19 @@
+name: Lint GitHub Actions workflow
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+
+jobs:
+  lint:
+    permissions:
+      contents: read
+    uses: shuymn/github-actions/.github/workflows/gha.yml@f63cdf176b96394e99ce1eb949e33945bf36cf80

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,21 @@
+name: Validate Renovate config
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/renovate.yml
+      - .github/renovate.json
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/renovate.yml
+      - .github/renovate.json
+
+jobs:
+  validate:
+    permissions:
+      contents: read
+    uses: shuymn/github-actions/.github/workflows/renovate.yml@f63cdf176b96394e99ce1eb949e33945bf36cf80

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,14 @@
+name: Security checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  security:
+    permissions:
+      contents: read
+    uses: shuymn/github-actions/.github/workflows/security.yml@f63cdf176b96394e99ce1eb949e33945bf36cf80

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://npm.flatt.tech/

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,14 +1,46 @@
+assert_lefthook_installed: true
+glob_matcher: doublestar
+no_tty: true
+skip_lfs: true
+
+output:
+  - summary
+  - failure
+  - execution
+  - execution_out
+
 commit-msg:
   commands:
     commitlint:
       run: bun run commitlint --edit {1}
 
 pre-commit:
-  parallel: true
+  parallel: false
+  piped: true
+
   commands:
     check:
-      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+      tags: [format, lint]
+      glob: "**/*.{js,jsx,ts,tsx,json,jsonc}"
       exclude:
         - "docs/"
       run: bun run biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
+    typecheck:
+      tags: [types]
+      run: bun run typecheck
+    betterleaks:
+      tags: [security]
+      run: betterleaks git --pre-commit --staged --redact --no-banner --verbose
+
+  skip:
+    - merge: true
+    - rebase: true
+
+pre-push:
+  piped: true
+
+  commands:
+    checks:
+      tags: [format, lint, types, test]
+      run: bun run check


### PR DESCRIPTION
## Summary

Align project configuration files with the upstream bun template and add CI workflows for GitHub Actions linting, Renovate validation, and security checks. The Renovate configuration is simplified by using a shared template from `github>shuymn/github-actions`.

## Changes

- **Renovate config**: Replace inline configuration with shared template `github>shuymn/github-actions#main`, keeping only project-specific custom managers
- **Lefthook config**: Align with bun template — add `assert_lefthook_installed`, `glob_matcher: doublestar`, `no_tty`, `skip_lfs`, output settings, sequential pre-commit with typecheck and security checks (`betterleaks`), and pre-push hooks
- **CI workflows**: Add GHA lint workflow, Renovate config validation workflow, and security checks workflow — all referencing shared templates from `shuymn/github-actions`
- **npm registry**: Add `.npmrc` pointing to `https://npm.flatt.tech/`

## Motivation

These changes bring the project's tooling and CI configuration in line with the standardized bun template, reducing maintenance overhead by delegating common config to shared templates and ensuring consistent code quality practices.

## Technical Details

- Renovate: Replaced inline `extends`, `labels`, `lockFileMaintenance`, `prHourlyLimit`, `minimumReleaseAge`, `packageRules`, etc. with a single `extends: ["github>shuymn/github-actions#main"]` entry
- Lefthook: Added global settings (`assert_lefthook_installed`, glob matcher, output config, `no_tty`), changed pre-commit to sequential (`parallel: false`, `piped: true`), added `typecheck` and `betterleaks` commands, added `pre-push` hook running `bun run check`
- CI: All three new workflows use reusable workflows from `shuymn/github-actions` at a pinned commit SHA, with minimal job config (permissions and trigger paths only)
- `.npmrc`: Single-line registry override to `https://npm.flatt.tech/`

## Impact

- Affected features: CI pipelines, local git hooks, Renovate dependency management, npm registry resolution
- Affected files: `.github/renovate.json`, `.github/workflows/gha.yml`, `.github/workflows/renovate.yml`, `.github/workflows/security.yml`, `.npmrc`, `lefthook.yml`
- Breaking changes: No

## Testing

1. Verify that `bun run check` passes locally
2. Verify that Renovate config validation workflow runs on PR
3. Verify that GHA lint workflow runs on PR with workflow changes
4. Verify that security checks workflow runs on PR

## Checklist

- [x] Code works as expected
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if necessary)
- [x] Linter and formatter have been run
- [ ] Breaking changes are clearly documented

## Additional Notes

The shared Renovate template from `github>shuymn/github-actions#main` centralizes common dependency management rules across repositories. CI workflows also reference pinned reusable workflows from the same shared repository.
